### PR TITLE
chore(package): update sass-loader to version 7.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "mocha": "^5.0.1",
     "node-sass": "^4.6.0",
     "nyc": "^11.5.0",
-    "sass-loader": "^6.0.6",
+    "sass-loader": "^7.0.1",
     "supertest": "^3.0.0",
     "vue-styleguidist": "^1.4.8"
   }


### PR DESCRIPTION
#38 wird geschlossen, weil dieser fehlgeschlagen hat und es schon ein update gab.